### PR TITLE
온보딩 단계에서 닉네임 검증 추가

### DIFF
--- a/src/main/java/com/soundscape/user/api/controller/OnboardingController.java
+++ b/src/main/java/com/soundscape/user/api/controller/OnboardingController.java
@@ -4,6 +4,7 @@ import com.soundscape.common.auth.context.UserContextHolder;
 import com.soundscape.common.response.CommonResponse;
 import com.soundscape.user.api.dto.OnboardingRequestDto;
 import com.soundscape.user.service.OnboardingService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,7 +15,7 @@ public class OnboardingController {
     private final OnboardingService onboardingService;
 
     @PostMapping
-    public CommonResponse onboarding(@RequestBody OnboardingRequestDto dto) {
+    public CommonResponse onboarding(@Valid @RequestBody OnboardingRequestDto dto) {
         Long userId = Long.valueOf(UserContextHolder.getUserContext());
         onboardingService.onboarding(userId, dto);
         return CommonResponse.success("온보딩 정보 입력 성공");

--- a/src/main/java/com/soundscape/user/api/dto/OnboardingRequestDto.java
+++ b/src/main/java/com/soundscape/user/api/dto/OnboardingRequestDto.java
@@ -1,5 +1,8 @@
 package com.soundscape.user.api.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,7 +11,14 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class OnboardingRequestDto {
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(max = 20, message = "닉네임은 20자 이내여야 합니다.")
+    @Pattern(
+            regexp = "^[A-Za-z가-힣]+$",
+            message = "닉네임은 한글 또는 영문만 사용할 수 있습니다."
+    )
     private String nickname;
+
     private List<String> artists;
     private List<String> genres;
 }


### PR DESCRIPTION
- 한글/영문 조합 최대 20자 제한
- 공백, 자음, 모음 불가
- postman 테스트 완료