### PR TITLE
추천엔진 호출 비동기 폴링방식으로 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+    implementation 'org.apache.commons:commons-text:1.15.0'
 
     implementation platform('io.jsonwebtoken:jjwt-root:0.13.0')
     implementation 'io.jsonwebtoken:jjwt-api'

--- a/src/main/java/com/soundscape/common/config/AsyncConfig.java
+++ b/src/main/java/com/soundscape/common/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.soundscape.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "asyncExecutor")
+    public Executor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(8);
+        taskExecutor.setMaxPoolSize(18);
+        taskExecutor.setQueueCapacity(0);
+        taskExecutor.setThreadNamePrefix("AsyncExecutor-");
+        taskExecutor.initialize();
+        return taskExecutor;
+    }
+}

--- a/src/main/java/com/soundscape/common/response/ErrorCode.java
+++ b/src/main/java/com/soundscape/common/response/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 
     // Playlist
     PLAYLIST_NOT_FOUND("존재하지 않는 플레이리스트입니다"),
+    PLAYLIST_GENERATION_TASK_NOT_FOUND("존재하지 않는 플레이리스트 생성 작업입니다: %s"),
 
     //UserPlaylist
     USER_PLAYLIST_NOT_FOUND("존재하지 않는 유저 플레이리스트입니다: %s");

--- a/src/main/java/com/soundscape/common/response/ErrorCode.java
+++ b/src/main/java/com/soundscape/common/response/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
 
     // Playlist
     PLAYLIST_NOT_FOUND("존재하지 않는 플레이리스트입니다"),
-    PLAYLIST_GENERATION_TASK_NOT_FOUND("존재하지 않는 플레이리스트 생성 작업입니다: %s"),
+    PLAYLIST_GENERATION_TASK_NOT_FOUND("존재하지 않는 플레이리스트 생성 작업입니다."),
 
     //UserPlaylist
     USER_PLAYLIST_NOT_FOUND("존재하지 않는 유저 플레이리스트입니다: %s");

--- a/src/main/java/com/soundscape/common/util/IdentifierGenerator.java
+++ b/src/main/java/com/soundscape/common/util/IdentifierGenerator.java
@@ -1,0 +1,20 @@
+package com.soundscape.common.util;
+
+import org.apache.commons.text.RandomStringGenerator;
+
+public class IdentifierGenerator {
+    private static final int ID_LENGTH = 20;
+
+    private static final RandomStringGenerator GENERATOR = new RandomStringGenerator.Builder()
+            .withinRange('0', 'z')
+            .filteredBy(Character::isLetterOrDigit)
+            .get();
+
+    public static String generateId(int length) {
+        return GENERATOR.generate(length);
+    }
+
+    public static String generateWithPrefix(String prefix) {
+        return prefix + generateId(ID_LENGTH - prefix.length());
+    }
+}

--- a/src/main/java/com/soundscape/playlist/api/controller/PlaylistControllerDoc.java
+++ b/src/main/java/com/soundscape/playlist/api/controller/PlaylistControllerDoc.java
@@ -16,6 +16,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface PlaylistControllerDoc {
     @Operation(summary = "플레이리스트 생성 API", description = "사용자 입력값을 바탕으로 스포티파이 플레이리스트를 생성합니다.")
     CommonResponse<PlaylistResponse> generatePlaylist(@RequestBody PlaylistRequest request);
+    @Operation(summary = "비동기 플레이리스트 생성 API", description = "사용자 입력값을 바탕으로 스포티파이 플레이리스트 생성 작업을 비동기로 시작합니다.")
+    CommonResponse generatePlaylistAsync(@RequestBody PlaylistRequest request);
+    @Operation(summary = "플레이리스트 생성 작업 상태 확인 API", description = "비동기 플레이리스트 생성 작업의 상태를 확인합니다. 생성이 완료되면 플레이리스트 정보를 반환합니다.")
+    CommonResponse checkPlaylistTask(@PathVariable String taskId);
     @Operation(summary = "플레이리스트 이름 수정 및 라이브러리 저장 API", description = "플레이리스트 이름을 수정하고 사용자의 라이브러리에 저장합니다.")
     CommonResponse savePlaylist(@PathVariable Long playlistId, @RequestBody PlaylistNameUpdateRequest newPlaylistName);
     @Operation(summary = "플레이리스트 라이브러리에서 삭제 API", description = "사용자의 라이브러리에서 플레이리스트를 삭제합니다.")

--- a/src/main/java/com/soundscape/playlist/api/dto/response/PlaylistTaskStatusResponse.java
+++ b/src/main/java/com/soundscape/playlist/api/dto/response/PlaylistTaskStatusResponse.java
@@ -1,0 +1,25 @@
+package com.soundscape.playlist.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class PlaylistTaskStatusResponse {
+
+    private final String taskId;
+    private final String status;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final PlaylistResponse playlistInfo;
+
+    public PlaylistTaskStatusResponse(String taskId, String status) {
+        this.taskId = taskId;
+        this.status = status;
+        this.playlistInfo = null;
+    }
+
+    public PlaylistTaskStatusResponse(String taskId, String status, PlaylistResponse playlistInfo) {
+        this.taskId = taskId;
+        this.status = status;
+        this.playlistInfo = playlistInfo;
+    }
+}

--- a/src/main/java/com/soundscape/playlist/domain/PlaylistGenerationTask.java
+++ b/src/main/java/com/soundscape/playlist/domain/PlaylistGenerationTask.java
@@ -1,0 +1,57 @@
+package com.soundscape.playlist.domain;
+
+import com.soundscape.common.jpa.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "playlist_generation_tasks")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PlaylistGenerationTask extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String taskId;
+
+    private Long userId;
+    private Long playlistId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TaskStatus status;
+
+    public PlaylistGenerationTask(String taskId, Long userId) {
+        this.taskId = taskId;
+        this.userId = userId;
+        this.status = TaskStatus.PENDING;
+    }
+
+    public void startTask() {
+        this.status = TaskStatus.IN_PROGRESS;
+    }
+
+    public void failTask() {
+        this.status = TaskStatus.FAILED;
+    }
+
+    public void completeTask(Long playlistId) {
+        this.playlistId = playlistId;
+        this.status = TaskStatus.COMPLETED;
+    }
+
+    public boolean isCompleted() {
+        return this.status == TaskStatus.COMPLETED;
+    }
+
+    public enum TaskStatus {
+        PENDING,
+        IN_PROGRESS,
+        COMPLETED,
+        FAILED
+    }
+}

--- a/src/main/java/com/soundscape/playlist/exception/TaskNotFoundException.java
+++ b/src/main/java/com/soundscape/playlist/exception/TaskNotFoundException.java
@@ -1,0 +1,15 @@
+package com.soundscape.playlist.exception;
+
+import com.soundscape.common.exception.EntityNotFoundException;
+import com.soundscape.common.response.ErrorCode;
+
+public class TaskNotFoundException extends EntityNotFoundException {
+
+    public TaskNotFoundException() {
+        super(ErrorCode.PLAYLIST_GENERATION_TASK_NOT_FOUND);
+    }
+
+    public TaskNotFoundException(String message) {
+        super(message, ErrorCode.PLAYLIST_GENERATION_TASK_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/soundscape/playlist/repository/PlaylistGenerationTaskRepository.java
+++ b/src/main/java/com/soundscape/playlist/repository/PlaylistGenerationTaskRepository.java
@@ -1,0 +1,11 @@
+package com.soundscape.playlist.repository;
+
+import com.soundscape.playlist.domain.PlaylistGenerationTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PlaylistGenerationTaskRepository extends JpaRepository<PlaylistGenerationTask, Long> {
+    Optional<PlaylistGenerationTask> findByTaskId(String taskId);
+    Optional<PlaylistGenerationTask> findByTaskIdAndUserId(String taskId, Long userId);
+}

--- a/src/main/java/com/soundscape/playlist/service/PlaylistGenerationService.java
+++ b/src/main/java/com/soundscape/playlist/service/PlaylistGenerationService.java
@@ -1,0 +1,98 @@
+package com.soundscape.playlist.service;
+
+import com.soundscape.playlist.api.dto.response.PlaylistResponse;
+import com.soundscape.playlist.api.dto.response.PlaylistTaskStatusResponse;
+import com.soundscape.playlist.domain.Playlist;
+import com.soundscape.playlist.domain.PlaylistCondition;
+import com.soundscape.playlist.domain.PlaylistGenerationTask;
+import com.soundscape.playlist.infra.spotify.SpotifyPlaylistClient;
+import com.soundscape.playlist.repository.PlaylistGenerationTaskRepository;
+import com.soundscape.playlist.repository.PlaylistRepository;
+import com.soundscape.playlist.service.command.PlaylistCommand;
+import com.soundscape.playlist.service.mapper.PlaylistMapper;
+import com.soundscape.user.domain.entity.User;
+import com.soundscape.user.service.UserReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import se.michaelthelin.spotify.model_objects.specification.Track;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlaylistGenerationService {
+
+    private final PlaylistGenerator playlistGenerator;
+    private final SpotifyPlaylistClient spotifyPlaylistClient;
+    private final PlaylistReader playlistReader;
+    private final UserReader userReader;
+    private final TaskReader taskReader;
+    private final PlaylistRepository playlistRepository;
+    private final PlaylistGenerationTaskRepository playlistGenerationTaskRepository;
+
+    @Async("asyncExecutor")
+    public void executeGeneration(Long userId, String taskId, PlaylistCommand command) {
+        PlaylistGenerationTask task = taskReader.getTask(taskId);
+
+        try {
+            task.startTask();
+            playlistGenerationTaskRepository.save(task);
+
+            User user = userReader.getUser(userId);
+            List<String> favArtists = user.getFavArtists();
+            PlaylistResponse result = playlistGenerator.generate(command, favArtists);
+            PlaylistCondition playlistCondition = new PlaylistCondition(command.getLocation(), command.getDecibel(), command.getGoal());
+            Playlist playlist = new Playlist(
+                    result.getPlaylistName(),
+                    result.getPlaylistUrl(),
+                    result.getSpotifyPlaylistId(),
+                    playlistCondition
+            );
+            playlistRepository.save(playlist);
+
+            task.completeTask(playlist.getId());
+            playlistGenerationTaskRepository.save(task);
+        } catch (Exception e) {
+            task.failTask();
+            playlistGenerationTaskRepository.save(task);
+            throw e;
+        }
+    }
+
+    public PlaylistTaskStatusResponse getTaskStatus(String taskId, Long userId){
+        PlaylistGenerationTask task = taskReader.getTaskWithUserId(taskId, userId);
+
+        if (task.isCompleted()) {
+            Playlist playlist = playlistReader.getPlaylist(task.getPlaylistId());
+            String spotifyPlaylistId = playlist.getSpotifyPlaylistId();
+            var spotifyPlaylistDetails = spotifyPlaylistClient.getPlaylistDetails(spotifyPlaylistId);
+
+            List<PlaylistResponse.Song> songs = Arrays.stream(spotifyPlaylistDetails.getTracks().getItems())
+                    .map(item -> {
+                        var itemElement = item.getTrack();
+                        if (itemElement instanceof Track track) {
+                            return PlaylistMapper.toSongFromSpotifyTrack(track);
+                        }
+                        return null;
+                    })
+                    .filter(java.util.Objects::nonNull)
+                    .toList();
+
+            PlaylistResponse response = PlaylistResponse.builder()
+                    .playlistId(playlist.getId())
+                    .playlistName(playlist.getPlaylistName())
+                    .location(playlist.getPlaylistCondition().getLocation())
+                    .goal(playlist.getPlaylistCondition().getGoal())
+                    .spotifyPlaylistId(spotifyPlaylistId)
+                    .playlistUrl(playlist.getPlaylistUrl())
+                    .songs(songs)
+                    .build();
+
+            return new PlaylistTaskStatusResponse(taskId, task.getStatus().name(), response);
+        }
+
+        return new PlaylistTaskStatusResponse(taskId, task.getStatus().name());
+    }
+}

--- a/src/main/java/com/soundscape/playlist/service/TaskReader.java
+++ b/src/main/java/com/soundscape/playlist/service/TaskReader.java
@@ -1,0 +1,24 @@
+package com.soundscape.playlist.service;
+
+import com.soundscape.playlist.domain.PlaylistGenerationTask;
+import com.soundscape.playlist.exception.TaskNotFoundException;
+import com.soundscape.playlist.repository.PlaylistGenerationTaskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TaskReader {
+
+    private final PlaylistGenerationTaskRepository playlistGenerationTaskRepository;
+
+    public PlaylistGenerationTask getTask(String taskId) {
+        return playlistGenerationTaskRepository.findByTaskId(taskId)
+                .orElseThrow(() -> new TaskNotFoundException("Invalid task ID: " + taskId));
+    }
+
+    public PlaylistGenerationTask getTaskWithUserId(String taskId, Long userId) {
+        return playlistGenerationTaskRepository.findByTaskIdAndUserId(taskId, userId)
+                .orElseThrow(() -> new TaskNotFoundException("Invalid task ID or user ID: " + taskId + ", " + userId));
+    }
+}


### PR DESCRIPTION
## 추천엔진 호출 비동기 폴링방식으로 전환

## 이슈
#39 

## 작업내용
- 플레이리스트 폴링 응답 DTO 추가 : taskId, 작업상태, 플레이리스트 정보 반환
- 랜덤문자열 기반으로 생성하는 task id 생성기 추가 -> 추후 대체키 에 활용 가능
- AsyncConfig: 최대 회원수만큼 맥스 스레드 수 설정
- 플레이리스트 생성 작업 관리 엔티티 추가-> DB에 저장
- 플레이리스트 비동기 aPI추가 -> 추후 동기 메서드는 삭제 예정
- 플레이리스트 생성 작업 조회 폴링 API 추가 -> status 필드가 COMPLETED일 때 기존 동기메서드에서 리턴하던 플레이리스트 정보 추가하여 리턴
